### PR TITLE
Update API doc and set api name explicitly

### DIFF
--- a/flock_controller/api_docs/doc.py
+++ b/flock_controller/api_docs/doc.py
@@ -157,7 +157,25 @@ doc = {
             "@id": "vocab:State",
             "@type": "hydra:Class",
             "description": "Class for drone state objects",
-            "supportedOperation": [],
+            "supportedOperation": [
+                {
+                    "@type": "http://schema.org/FindAction",
+                    "expects": "null",
+                    "method": "GET",
+                    "possibleStatus": [
+                        {
+                            "description": "State not found",
+                            "statusCode": 404
+                        },
+                        {
+                            "description": "State Returned",
+                            "statusCode": 200
+                        }
+                    ],
+                    "returns": "vocab:State",
+                    "title": "GetState"
+                }
+            ],
             "supportedProperty": [
                 {
                     "@type": "SupportedProperty",

--- a/flock_controller/api_docs/doc.py
+++ b/flock_controller/api_docs/doc.py
@@ -745,6 +745,49 @@ doc = {
             ],
             "title": "CommandCollection"
         },
+	{
+            "@id": "vocab:StateCollection",
+            "@type": "hydra:Class",
+            "description": "A collection of state",
+            "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
+            "supportedOperation": [
+                {
+                    "@id": "_:state_collection_retrieve",
+                    "@type": "http://schema.org/FindAction",
+                    "description": "Retrieves all State entities",
+                    "expects": "null",
+                    "method": "GET",
+                    "returns": "vocab:StateCollection",
+                    "statusCodes": []
+                },
+                {
+                    "@id": "_:state_create",
+                    "@type": "http://schema.org/AddAction",
+                    "description": "Create new State entitity",
+                    "expects": "vocab:State",
+                    "method": "PUT",
+                    "returns": "vocab:State",
+                    "statusCodes": [
+                        {
+                            "description": "If the State entity was created successfully.",
+                            "statusCode": 201
+                        }
+                    ]
+                }
+            ],
+            "supportedProperty": [
+                {
+                    "@type": "SupportedProperty",
+                    "description": "The state",
+                    "property": "http://www.w3.org/ns/hydra/core#member",
+                    "readonly": "false",
+                    "required": "false",
+                    "title": "members",
+                    "writeonly": "false"
+                }
+            ],
+            "title": "StateCollection"
+        },
         {
             "@id": "vocab:ControllerLogCollection",
             "@type": "hydra:Class",
@@ -1158,6 +1201,46 @@ doc = {
                                 "statusCodes": [
                                     {
                                         "description": "If the Command entity was created successfully.",
+                                        "statusCode": 201
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "readonly": "true",
+                    "required": "null",
+                    "writeonly": "false"
+                },
+		{
+                    "hydra:description": "The StateCollection collection",
+                    "hydra:title": "statecollection",
+                    "property": {
+                        "@id": "vocab:EntryPoint/StateCollection",
+                        "@type": "hydra:Link",
+                        "description": "The StateCollection collection",
+                        "domain": "vocab:EntryPoint",
+                        "label": "StateCollection",
+                        "range": "vocab:StateCollection",
+                        "supportedOperation": [
+                            {
+                                "@id": "_:state_collection_retrieve",
+                                "@type": "http://schema.org/FindAction",
+                                "description": "Retrieves all State entities",
+                                "expects": "null",
+                                "method": "GET",
+                                "returns": "vocab:StateCollection",
+                                "statusCodes": []
+                            },
+                            {
+                                "@id": "_:state_create",
+                                "@type": "http://schema.org/AddAction",
+                                "description": "Create new State entitity",
+                                "expects": "vocab:State",
+                                "method": "PUT",
+                                "returns": "vocab:State",
+                                "statusCodes": [
+                                    {
+                                        "description": "If the State entity was created successfully.",
                                         "statusCode": 201
                                     }
                                 ]

--- a/flock_controller/api_docs/doc_gen.py
+++ b/flock_controller/api_docs/doc_gen.py
@@ -227,7 +227,7 @@ def doc_gen(API, BASE_URL):
                                            {"statusCode": 200, "description": "Anomaly successfully deleted."}]))
 
     api_doc.add_supported_class(drone, collection=True)
-    api_doc.add_supported_class(state, collection=False)
+    api_doc.add_supported_class(state, collection=True)
     api_doc.add_supported_class(datastream, collection=True)
     api_doc.add_supported_class(dronelog, collection=True)
     api_doc.add_supported_class(controllerlog, collection=True)

--- a/flock_controller/api_docs/doc_gen.py
+++ b/flock_controller/api_docs/doc_gen.py
@@ -31,6 +31,13 @@ def doc_gen(API, BASE_URL):
         "https://schema.org/status", "Status", False, False, True))
     state.add_supported_prop(HydraClassProp(
         "http://schema.org/identifier", "DroneID", False, False, True))
+    
+    state.add_supported_op(HydraClassOp("GetState",
+                                        "GET",
+                                        None,
+                                        "vocab:State",
+                                        [{"statusCode": 404, "description": "State not found"},
+                                         {"statusCode": 200, "description": "State Returned"}]))
 
     # Drone Class
     drone = HydraClass("Drone", "Drone", "Class for a drone")

--- a/flock_controller/main.py
+++ b/flock_controller/main.py
@@ -1,6 +1,6 @@
 """Script for setting up Hydrus with flock_drone API Doc."""
 from hydrus.app_factory import app_factory
-from hydrus.utils import set_session, set_doc, set_hydrus_server_url
+from hydrus.utils import set_session, set_doc, set_hydrus_server_url, set_api_name
 from hydrus.utils import set_authentication, set_token
 # from hydrus.app import set_session, set_doc, set_hydrus_server_url
 from hydrus.data import doc_parse
@@ -40,10 +40,11 @@ if __name__ == "__main__":
 
     app = app_factory(API_NAME)
 
-    with set_doc(app, apidoc):
-        with set_authentication(app, False):
-            with set_token(app, True):
-                with set_hydrus_server_url(app, HYDRUS_SERVER_URL):
-                    with set_session(app, session):
-                        http_server = WSGIServer(('', PORT), app)
-                        http_server.serve_forever()
+    with set_api_name(app, API_NAME):
+        with set_doc(app, apidoc):
+            with set_authentication(app, False):
+                with set_token(app, True):
+                    with set_hydrus_server_url(app, HYDRUS_SERVER_URL):
+                        with set_session(app, session):
+                            http_server = WSGIServer(('', PORT), app)
+                            http_server.serve_forever()


### PR DESCRIPTION
Related to https://github.com/HTTP-APIs/hydrus/issues/374
@xadahiya 
It was a hideous bug, as we can see from the error report you posted at https://github.com/HTTP-APIs/hydrus/issues/374, get_doc() was returning string instead of the ApiDoc. And that string was name of the api.(I can't say for sure how/why get_doc() was returning api_name(it works fine in hydrus repo)) I tried to set api_name explicitly and it is working now. I have also updated the API doc. 